### PR TITLE
Updated Podfile and corrected casing of Xcode

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,12 @@
 # CastHelloText-ios
 platform :ios, '6.0'
-pod 'google-cast-sdk'
-link_with 'HelloTextGoogleCastObjectiveC', 'HelloTextGoogleCastSwift'
+
+target 'HelloTextGoogleCastObjectiveC' do
+  pod 'google-cast-sdk'
+end
+
+target 'HelloTextGoogleCastSwift' do
+  use_frameworks!
+
+  pod 'google-cast-sdk'
+end

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This Hello Text demo application shows how an iOS sender application can send an
 
 ## Setup Instructions (Without CocoaPods)
 * Get a Chromecast device and get it set up for development: https://developers.google.com/cast/docs/developers#Get_started
-* Setup the project dependencies in xCode
+* Setup the project dependencies in Xcode
 * For each target you want to build, under "Build Settings", add "-ObjC" to "Other Linker Flags"
 * For each target you want to build, under "Build Phases", add the following entries to "Link Binary With Libraries":
   * libc++.dylib


### PR DESCRIPTION
The primary benefit of this PR, is that you can use a recent version of CocoaPods, to install the pod(s). `link_with` was removed in version 1.0.

Tested with CocoaPods 1.1.1.